### PR TITLE
Refactoring

### DIFF
--- a/lib/every.ex
+++ b/lib/every.ex
@@ -74,8 +74,8 @@ defmodule Every do
   ## Examples
 
       iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
-      iex> Every.hour(now)
-      768
+      iex> Every.hours(2, now)
+      4308
   """
   def hours(interval, relative_to) when is_nil(relative_to) do
     hours(interval, Timex.now())

--- a/lib/every.ex
+++ b/lib/every.ex
@@ -20,7 +20,7 @@ defmodule Every do
 
   ## Examples
 
-      iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
+      iex> now = Timex.parse!("2018-10-14T16:48:12.000Z", "{ISO:Extended}")
       iex> Every.minute(now)
       48
   """
@@ -34,7 +34,7 @@ defmodule Every do
 
   ## Examples
 
-      iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
+      iex> now = Timex.parse!("2018-10-14T16:48:12.000Z", "{ISO:Extended}")
       iex> Every.minutes(5, now)  # 16:50 > 15:50:00 - 16:48:12
       108
   """
@@ -59,7 +59,7 @@ defmodule Every do
 
   ## Examples
 
-      iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
+      iex> now = Timex.parse!("2018-10-14T16:48:12.000Z", "{ISO:Extended}")
       iex> Every.hour(now)
       708
   """
@@ -80,7 +80,7 @@ defmodule Every do
 
   ## Examples
 
-      iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
+      iex> now = Timex.parse!("2018-10-14T16:48:12.000Z", "{ISO:Extended}")
       iex> Every.hours(2, now)
       4308
   """
@@ -106,7 +106,7 @@ defmodule Every do
 
   ## Examples
 
-      iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
+      iex> now = Timex.parse!("2018-10-14T16:48:12.000Z", "{ISO:Extended}")
       iex> Every.day(now)  # Time remaining 7h 25m 48s
       25908
   """

--- a/lib/every.ex
+++ b/lib/every.ex
@@ -40,6 +40,7 @@ defmodule Every do
   """
   def minutes(interval, relative_to \\ Timex.now())
 
+  @deprecated "Use minutes/1 instead"
   def minutes(interval, nil), do: minutes(interval)
 
   def minutes(interval, relative_to) do
@@ -86,6 +87,7 @@ defmodule Every do
   """
   def hours(interval, relative_to \\ Timex.now())
 
+  @deprecated "Use hours/1 instead"
   def hours(interval, nil), do: hours(interval)
 
   def hours(interval, relative_to) do

--- a/lib/every.ex
+++ b/lib/every.ex
@@ -13,7 +13,6 @@ defmodule Every do
   if it is provided then duration in seconds until next
   call will be calculated relative to given `relative_to`.
   """
-  use Timex
 
   @doc """
   Calculate how many seconds left

--- a/lib/every.ex
+++ b/lib/every.ex
@@ -1,29 +1,24 @@
 defmodule Every do
   @moduledoc """
-  Every gives you ability to use `Process.send_after/3`
-  with calculated intervals which can be rounded to every
-  (note: all functions return values only in seconds)
+  Every gives you ability to use `Process.send_after/3` with calculated
+  intervals which can be rounded to every:
 
     1. Minute,
     2. N minutes,
     3. Hour,
     4. N Hours.
 
-  Every method accepts optional `relative_to` parameter
-  if it is provided then duration in seconds until next
-  call will be calculated relative to given `relative_to`.
+  Every function accepts an optional `relative_to` parameter, which can be used
+  to fake the current moment in time. If it is not provided, the current time
+  will be used.
+
+  **Note:** All functions return the difference in seconds!
   """
 
   @doc """
-  Calculate how many seconds left
-  until next minute starts.
+  Calculates how many seconds left until the next minute starts.
 
-  If `relative_to` `DateTime` is not provided
-  then current moment in time is used.
-
-  Returns: `integer` number of seconds.
-
-  ## Example
+  ## Examples
 
       iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
       iex> Every.minute(now)
@@ -35,13 +30,10 @@ defmodule Every do
   end
 
   @doc """
-  Calculate how many minutes left
-  until next interval when relative
-  `DateTime` is not provided and equals to `nil`.
+  Calculates how many seconds left until the next interval (minutes) will be
+  reached.
 
-  Returns: `integer` number of seconds.
-
-  ## Example
+  ## Examples
 
       iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
       iex> Every.minutes(5, now)  # 16:50 > 15:50:00 - 16:48:12
@@ -51,21 +43,6 @@ defmodule Every do
     minutes(interval, Timex.now())
   end
 
-  @doc """
-  Calculate how many minutes left
-  until next interval.
-
-  If `relative_to` `DateTime` is not provided
-  then current moment in time is used.
-
-  Returns: `integer` number of seconds.
-
-  ## Example
-
-      iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
-      iex> Every.minutes(5, now)  # 16:50 > 15:50:00 - 16:48:12
-      108
-  """
   def minutes(interval, relative_to) do
     next_due = get_next_interval(relative_to.minute, interval) - relative_to.minute
 
@@ -76,15 +53,9 @@ defmodule Every do
   end
 
   @doc """
-  Calculate how many minutes left
-  until next hour starts.
+  Calculates how many seconds left until the next hour starts.
 
-  If `relative_to` `DateTime` is not provided
-  then current moment in time is used.
-
-  Returns: `integer` number of seconds.
-
-  ## Example
+  ## Examples
 
       iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
       iex> Every.hour(now)
@@ -97,15 +68,10 @@ defmodule Every do
   end
 
   @doc """
-  Calculate how many minutes left
-  until next hour starts.
+  Calculates how many seconds left until the next interval (hours) will be
+  reached.
 
-  If `relative_to` `DateTime` is not provided
-  then current moment in time is used.
-
-  Returns: `integer` number of seconds.
-
-  ## Example
+  ## Examples
 
       iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
       iex> Every.hour(now)
@@ -115,21 +81,6 @@ defmodule Every do
     hours(interval, Timex.now())
   end
 
-  @doc """
-  Calculate how many minutes left
-  until next hour starts.
-
-  If `relative_to` `DateTime` is not provided
-  then current moment in time is used.
-
-  Returns: `integer` number of seconds.
-
-  ## Example
-
-      iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
-      iex> Every.hour(now)
-      768
-  """
   def hours(interval, relative_to) do
     next_due = get_next_interval(relative_to.hour, interval) - relative_to.hour
     minutes_left = 60 - relative_to.minute
@@ -138,14 +89,9 @@ defmodule Every do
   end
 
   @doc """
-  Calculate interval until next day.
+  Calculates how many seconds left until the next day starts.
 
-  If `relative_to` `DateTime` is not provided
-  then current moment in time is used.
-
-  Returns: `integer` number of seconds.
-
-  ## Example
+  ## Examples
 
       iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
       iex> Every.day(now)  # Time remaining 7h 25m 48s

--- a/lib/every.ex
+++ b/lib/every.ex
@@ -59,12 +59,12 @@ defmodule Every do
 
       iex> {:ok, now, _} = DateTime.from_iso8601("2018-10-14T16:48:12.000Z")
       iex> Every.hour(now)
-      768
+      708
   """
   def hour(relative_to \\ Timex.now()) do
     minutes_left = 60 - relative_to.minute
     seconds_left = 60 - relative_to.second
-    60 * minutes_left + seconds_left
+    60 * (minutes_left - 1) + seconds_left
   end
 
   @doc """
@@ -85,7 +85,7 @@ defmodule Every do
     next_due = get_next_interval(relative_to.hour, interval) - relative_to.hour
     minutes_left = 60 - relative_to.minute
     seconds_left = 60 - relative_to.second
-    3600 * (next_due - 1) + 60 * minutes_left + seconds_left
+    3600 * (next_due - 1) + 60 * (minutes_left - 1) + seconds_left
   end
 
   @doc """

--- a/test/every_test.exs
+++ b/test/every_test.exs
@@ -41,24 +41,24 @@ defmodule EveryTest do
     {:ok, datetime, _} = DateTime.from_iso8601(@date_string)
 
     # Next time at 17:00
-    assert Every.hour(datetime) == 768
+    assert Every.hour(datetime) == 708
   end
 
   test "Every N hours works as expected" do
     {:ok, datetime, _} = DateTime.from_iso8601(@date_string)
 
     # Next time at 18:00
-    assert Every.hours(2, datetime) == 4368
+    assert Every.hours(2, datetime) == 4308
 
     # Next time at 17:00
-    assert Every.hours(1, datetime) == 768
+    assert Every.hours(1, datetime) == 708
 
     # Next time at 22:00 because of remaining time
     # is about ~4.21 hours.
-    assert Every.hours(10, datetime) == 11_568
+    assert Every.hours(10, datetime) == 11_508
 
     # 1:12:48 til next time
-    assert Every.hours(3, datetime) == 4368
+    assert Every.hours(3, datetime) == 4308
   end
 
   test "Every N hours without relative time works as expected" do

--- a/test/every_test.exs
+++ b/test/every_test.exs
@@ -5,12 +5,12 @@ defmodule EveryTest do
   @date_string "2018-10-14T16:48:12.000Z"
 
   test "Every minute works as expected" do
-    {:ok, datetime, _} = DateTime.from_iso8601(@date_string)
+    datetime = Timex.parse!(@date_string, "{ISO:Extended}")
     assert Every.minute(datetime) == 48
   end
 
   test "Every N minutes works as expected" do
-    {:ok, datetime, _} = DateTime.from_iso8601(@date_string)
+    datetime = Timex.parse!(@date_string, "{ISO:Extended}")
     # Next time is expected to be at 16:50 because
     # 50 % 5 == 0 etc. for all examples.
     assert Every.minutes(5, datetime) == 108
@@ -38,14 +38,14 @@ defmodule EveryTest do
   end
 
   test "Every hour works as expected" do
-    {:ok, datetime, _} = DateTime.from_iso8601(@date_string)
+    datetime = Timex.parse!(@date_string, "{ISO:Extended}")
 
     # Next time at 17:00
     assert Every.hour(datetime) == 708
   end
 
   test "Every N hours works as expected" do
-    {:ok, datetime, _} = DateTime.from_iso8601(@date_string)
+    datetime = Timex.parse!(@date_string, "{ISO:Extended}")
 
     # Next time at 18:00
     assert Every.hours(2, datetime) == 4308
@@ -69,7 +69,7 @@ defmodule EveryTest do
   end
 
   test "Every day works as expected" do
-    {:ok, datetime, _} = DateTime.from_iso8601(@date_string)
+    datetime = Timex.parse!(@date_string, "{ISO:Extended}")
 
     # Time remaining 7h 25m 48s
     assert Every.day(datetime) == 25_908

--- a/test/every_test.exs
+++ b/test/every_test.exs
@@ -2,15 +2,15 @@ defmodule EveryTest do
   use ExUnit.Case
   doctest Every
 
-  @date_string "2018-10-14T16:48:12.000Z"
+  setup do
+    {:ok, datetime: Timex.parse!("2018-10-14T16:48:12.000Z", "{ISO:Extended}")}
+  end
 
-  test "Every minute works as expected" do
-    datetime = Timex.parse!(@date_string, "{ISO:Extended}")
+  test "Every minute works as expected", %{datetime: datetime} do
     assert Every.minute(datetime) == 48
   end
 
-  test "Every N minutes works as expected" do
-    datetime = Timex.parse!(@date_string, "{ISO:Extended}")
+  test "Every N minutes works as expected", %{datetime: datetime} do
     # Next time is expected to be at 16:50 because
     # 50 % 5 == 0 etc. for all examples.
     assert Every.minutes(5, datetime) == 108
@@ -37,16 +37,12 @@ defmodule EveryTest do
     assert Every.minutes(2, nil) <= 120
   end
 
-  test "Every hour works as expected" do
-    datetime = Timex.parse!(@date_string, "{ISO:Extended}")
-
+  test "Every hour works as expected", %{datetime: datetime} do
     # Next time at 17:00
     assert Every.hour(datetime) == 708
   end
 
-  test "Every N hours works as expected" do
-    datetime = Timex.parse!(@date_string, "{ISO:Extended}")
-
+  test "Every N hours works as expected", %{datetime: datetime} do
     # Next time at 18:00
     assert Every.hours(2, datetime) == 4308
 
@@ -68,9 +64,7 @@ defmodule EveryTest do
     assert Every.hours(2, nil) / 3600 <= 2
   end
 
-  test "Every day works as expected" do
-    datetime = Timex.parse!(@date_string, "{ISO:Extended}")
-
+  test "Every day works as expected", %{datetime: datetime} do
     # Time remaining 7h 25m 48s
     assert Every.day(datetime) == 25_908
   end


### PR DESCRIPTION
I've refactored the library a bit :blush:

* dropped not needed `use Timex` (it only aliases some modules that aren't used in 'every')
* updated wording and removed redundant text from `@moduledoc` and `@doc` comments
* use Timex for some more calculations instead of doing it by yourself
* fixed a bug with calculating the interval in `hour/1` and `hours/2`
* parse datetime in `setup` and pass as `context` into tests to parse only once
* test `hours/2` instead of `hour/1` in doctest for `hours/2` :wink:
* use more common `## Examples` (was `## Example`, singular)
* marked `minutes(interval, nil)` and `hours(interval, nil)` as deprecated

#hacktoberfest